### PR TITLE
Change default host to 127.0.0.1

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ class Dymo {
 	constructor(options) {
 		options = options || {};
 
-		this.hostname = options.hostname || 'localhost';
+		this.hostname = options.hostname || '127.0.0.1';
 		this.port = options.port || 41951;
 		this.printerName = options.printerName;
 	}


### PR DESCRIPTION
Newer versions of the DLS API are checking the host when a request is made. Firing off a request to the v8.7.2 API on macOS leads to a `Bad Request (Invalid host)` error. Changing `localhost` to `127.0.0.1` fixes this, and as a bonus makes it slightly more secure.