### PR TITLE
README: Add syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,18 @@ npm i dymojs
 
 ### usage
 
-```
+```javascript
 const Dymo = require('dymojs'),
 	   dymo = new Dymo();
+
+// Assign Label XML information to a labelXml variable, see below
 
 dymo.print('DYMO LabelWriter 450', labelXml);
 ```
 
 render a label preview
 
-```
+```javascript
 dymo.renderLabel(labelXml).then(imageData => {
 	// returns imageData as base64 encoded png.
 	// use <img src="data:image/png;base64,${imageData}"/>
@@ -42,18 +44,16 @@ dymo.renderLabel(labelXml).then(imageData => {
 ```
 
 ### how do I get the xml for a label?
-Open the free `DYMO Label` software and design a label.  When you have designed one save it.  The file it saves is an XML document like the one below.  Simply pass that XML or (hint hint) a version of that XML that you did some string replacement on to the print function with a printer name and you are printing labels.
+Open the free `DYMO Label` software and design a label.  When you have designed one, save it.  The file it saves is an XML document like the one below.  Simply pass that XML or (hint hint) a version of that XML that you did some string replacement on to the print function with a printer name and you are printing labels.
 
 ### working example that prints a test label
-This example will print TEST123 on a shipping size label (2 1/8" x 4") to a printer named 'DYMO LabelWriter 450'. 
+This example will print TEST123 on a shipping size label (2 1/8" x 4") to a printer named `DYMO LabelWriter 450`. 
 
-```
+```javascript
 const Dymo = require('dymojs'),
 	   dymo = new Dymo();
 
-dymo.print('DYMO LabelWriter 450', labelXml);
-
-var labelXml = `
+let labelXml = `
 <?xml version="1.0" encoding="utf-8"?>
 <DieCutLabel Version="8.0" Units="twips">
   <PaperOrientation>Landscape</PaperOrientation>
@@ -99,5 +99,7 @@ var labelXml = `
   </ObjectInfo>
 </DieCutLabel>
 `;
+
+dymo.print('DYMO LabelWriter 450', labelXml);
 ```
 										


### PR DESCRIPTION
And clarify two examples: add a note about labelXml having to have information in it. And, assign the example information to it before use in the latter case.